### PR TITLE
ODROID-XU4: Introduce device tree overlay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 *.c.[012]*.*
 *.dt.yaml
 *.dtb
+*.dtbo
 *.dtb.S
 *.dwo
 *.elf

--- a/Makefile
+++ b/Makefile
@@ -1242,6 +1242,9 @@ ifneq ($(dtstree),)
 %.dtb: include/config/kernel.release scripts_dtc
 	$(Q)$(MAKE) $(build)=$(dtstree) $(dtstree)/$@
 
+%.dtbo:
+	$(Q)$(MAKE) $(build)=$(dtstree)/overlays $(dtstree)/overlays/$@
+
 PHONY += dtbs dtbs_install dt_binding_check
 dtbs dtbs_check: include/config/kernel.release scripts_dtc
 	$(Q)$(MAKE) $(build)=$(dtstree)

--- a/arch/arm/boot/dts/Makefile
+++ b/arch/arm/boot/dts/Makefile
@@ -1303,3 +1303,7 @@ dtb-$(CONFIG_ARCH_ASPEED) += \
 	aspeed-bmc-opp-zaius.dtb \
 	aspeed-bmc-portwell-neptune.dtb \
 	aspeed-bmc-quanta-q71l.dtb
+
+targets += $(dtb-y)
+
+subdir-y := overlays

--- a/arch/arm/boot/dts/exynos5422-odroidxu4.dts
+++ b/arch/arm/boot/dts/exynos5422-odroidxu4.dts
@@ -143,25 +143,25 @@
 
 /* i2c@12C70000 */
 &i2c_1 {
-	status = "okay";
+	status = "disabled";
 	samsung,i2c-max-bus-freq = <400000>;
 };
 
 /* i2c@12cb0000 */
 &hsi2c_5 {
-	status = "okay";
+	status = "disabled";
 	samsung,hs-mode;
 	clock-frequency = <400000>;
 };
 
 &spi_1 {
-	status = "okay";
+	status = "disabled";
 	samsung,spi-src-clk = <0>;
 	num-cs = <2>;
 	cs-gpios = <&gpa2 5 GPIO_ACTIVE_HIGH>, <&gpx2 1 GPIO_ACTIVE_HIGH>;
 
 	spidev: spidev@0 {
-		status = "okay";
+		status = "disabled";
 		reg = <0>;
 		compatible = "odroid,spidev";
 		spi-max-frequency = <1000000>;

--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -1,0 +1,12 @@
+# Overlays for the Odroid platform
+
+dtbo-y += \
+	spidev1-overlay.dtbo \
+	i2c1-overlay.dtbo \
+	i2c5-overlay.dtbo \
+	hktft32-overlay.dtbo \
+	hktft35-overlay.dtbo \
+	hktft-cs-ogst-overlay.dtbo
+
+targets += $(dtbo-y)
+always	:= $(dtbo-y)

--- a/arch/arm/boot/dts/overlays/hktft-cs-ogst-overlay.dts
+++ b/arch/arm/boot/dts/overlays/hktft-cs-ogst-overlay.dts
@@ -1,0 +1,36 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&i2c_1>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@1 {
+		target = <&hsi2c_5>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@2 {
+		target = <&spi_1>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@3 {
+		target = <&hktft_cs_ogst>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/hktft32-overlay.dts
+++ b/arch/arm/boot/dts/overlays/hktft32-overlay.dts
@@ -1,0 +1,36 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&i2c_1>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@1 {
+		target = <&hsi2c_5>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@2 {
+		target = <&spi_1>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@3 {
+		target = <&hktft32>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/hktft35-overlay.dts
+++ b/arch/arm/boot/dts/overlays/hktft35-overlay.dts
@@ -1,0 +1,36 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&i2c_1>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@1 {
+		target = <&hsi2c_5>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@2 {
+		target = <&spi_1>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@3 {
+		target = <&hktft35>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/i2c1-overlay.dts
+++ b/arch/arm/boot/dts/overlays/i2c1-overlay.dts
@@ -1,0 +1,12 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&i2c_1>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/i2c5-overlay.dts
+++ b/arch/arm/boot/dts/overlays/i2c5-overlay.dts
@@ -1,0 +1,12 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&hsi2c_5>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+};

--- a/arch/arm/boot/dts/overlays/spidev1-overlay.dts
+++ b/arch/arm/boot/dts/overlays/spidev1-overlay.dts
@@ -1,0 +1,20 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&spi_1>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@1 {
+		target = <&spidev>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+};

--- a/scripts/Makefile.dtbinst
+++ b/scripts/Makefile.dtbinst
@@ -20,6 +20,7 @@ include scripts/Kbuild.include
 include $(src)/Makefile
 
 dtbinst-files	:= $(sort $(dtb-y) $(if $(CONFIG_OF_ALL_DTBS), $(dtb-)))
+dtboinst-files	:= $(sort $(dtbo-y) $(if $(CONFIG_OF_ALL_DTBS), $(dtb-)))
 dtbinst-dirs	:= $(subdir-y) $(subdir-m)
 
 # Helper targets for Installing DTBs into the boot directory
@@ -31,10 +32,13 @@ install-dir = $(patsubst $(dtbinst_root)%,$(INSTALL_DTBS_PATH)%,$(obj))
 $(dtbinst-files): %.dtb: $(obj)/%.dtb
 	$(call cmd,dtb_install,$(install-dir))
 
+$(dtboinst-files): %.dtbo: $(obj)/%.dtbo
+	$(call cmd,dtb_install,$(install-dir))
+
 $(dtbinst-dirs):
 	$(Q)$(MAKE) $(dtbinst)=$(obj)/$@
 
-PHONY += $(dtbinst-files) $(dtbinst-dirs)
-__dtbs_install: $(dtbinst-files) $(dtbinst-dirs)
+PHONY += $(dtbinst-files) $(dtboinst-files) $(dtbinst-dirs)
+__dtbs_install: $(dtbinst-files) $(dtboinst-files) $(dtbinst-dirs)
 
 .PHONY: $(PHONY)

--- a/scripts/Makefile.lib
+++ b/scripts/Makefile.lib
@@ -254,12 +254,14 @@ DTC ?= $(objtree)/scripts/dtc/dtc
 ifeq ($(findstring 1,$(KBUILD_EXTRA_WARN)),)
 DTC_FLAGS += -Wno-unit_address_vs_reg \
 	-Wno-unit_address_format \
+	-Wno-gpios_property \
 	-Wno-avoid_unnecessary_addr_size \
 	-Wno-alias_paths \
 	-Wno-graph_child_address \
 	-Wno-simple_bus_reg \
 	-Wno-unique_unit_address \
-	-Wno-pci_device_reg
+	-Wno-pci_device_reg \
+	--symbol
 endif
 
 ifneq ($(findstring 2,$(KBUILD_EXTRA_WARN)),)
@@ -312,6 +314,18 @@ endef
 
 $(obj)/%.dt.yaml: $(src)/%.dts $(DTC) $(DT_TMP_SCHEMA) FORCE
 	$(call if_changed_rule,dtc_dt_yaml)
+
+quiet_cmd_dtco = DTCO    $@
+cmd_dtco = mkdir -p $(dir ${dtc-tmp}) ; \
+	$(CPP) $(dtc_cpp_flags) -x assembler-with-cpp -o $(dtc-tmp) $< ; \
+	$(DTC) -@ -H epapr -O dtb -o $@ -b 0 \
+		-i $(dir $<) $(DTC_FLAGS) \
+		-Wno-interrupts_property \
+		-d $(depfile).dtc.tmp $(dtc-tmp) ; \
+	cat $(depfile).pre.tmp $(depfile).dtc.tmp > $(depfile)
+
+$(obj)/%.dtbo: $(obj)/%.dts FORCE
+	$(call if_changed_dep,dtco)
 
 dtc-tmp = $(subst $(comma),_,$(dot-target).dts.tmp)
 


### PR DESCRIPTION
Copy *.dtbo files at arch/arm/boot/dts/overlays to boot
partition, e.g, /media/boot/overlays/. Then use "fdtoverlay" tool
to integrate DTB and DTBOs. Or, you also can use "fdt apply" u-boot
command to prepare device tree blob at booting time.

Signed-off-by: Yang Deokgyu <secugyu@gmail.com>
Change-Id: I40e6a915e2149952fb548f64e7fae335ba12db18

-----

This is the initial commit for supporting DTBO.

Still needs some guides but I'll fill it out soon. :)